### PR TITLE
Add feedback via email

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,7 +9,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 25
         versionCode 1
-        versionName "0.6.0"
+        versionName "0.6.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/src/main/java/com/nightcap/previously/AboutActivity.java
+++ b/app/src/main/java/com/nightcap/previously/AboutActivity.java
@@ -1,5 +1,6 @@
 package com.nightcap.previously;
 
+import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.v7.app.ActionBar;
@@ -13,6 +14,7 @@ import android.widget.TextView;
  */
 public class AboutActivity extends AppCompatActivity {
     private String TAG = "AboutActivity";
+    String versionNumber;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -33,7 +35,7 @@ public class AboutActivity extends AppCompatActivity {
 
         // Version number
         TextView versionView = (TextView) findViewById(R.id.about_version);
-        String versionNumber = "<Unknown>";
+        versionNumber = "<Unknown>";
 
         try {
             versionNumber = getApplicationContext().getPackageManager()
@@ -60,7 +62,7 @@ public class AboutActivity extends AppCompatActivity {
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-//        getMenuInflater().inflate(R.menu.menu_about, menu);
+        getMenuInflater().inflate(R.menu.menu_about, menu);
 
         return super.onCreateOptionsMenu(menu);
     }
@@ -71,6 +73,26 @@ public class AboutActivity extends AppCompatActivity {
             case android.R.id.home:
                 // If app icon in Action Bar clicked, go home
                 finish();
+                return true;
+            case R.id.action_email_feedback:
+                // Intent to send feedback via email
+                final Intent emailFeedback = new Intent(android.content.Intent.ACTION_SEND);
+                String devEmails[] = { "paul.wong.88@gmail.com", "andrian.sue@outlook.com",
+                        "williamxn.z@gmail.com" };
+
+                emailFeedback.setType("plain/text");
+                emailFeedback.putExtra(android.content.Intent.EXTRA_EMAIL, devEmails);
+                emailFeedback.putExtra(android.content.Intent.EXTRA_SUBJECT, "Feedback for " +
+                        getString(R.string.app_name) + " | Version " + versionNumber);
+                emailFeedback.putExtra(android.content.Intent.EXTRA_TEXT,
+                        "General comments:\n" +
+                                "> \n\n" +
+                                "Bugs:\n" +
+                                "> \n\n" +
+                                "Suggestions:\n" +
+                                ">" + " ");
+
+                startActivity(emailFeedback);
                 return true;
             default:
                 return super.onOptionsItemSelected(item);

--- a/app/src/main/res/layout/content_about.xml
+++ b/app/src/main/res/layout/content_about.xml
@@ -54,7 +54,7 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentStart="true"
                 android:layout_below="@+id/about_name"
-                style="@style/TextAppearance.AppCompat.Small"
+                android:textSize="@dimen/text_size_normal"
                 android:text="@string/about_version" />
             <TextView
                 android:id="@+id/about_build_date"
@@ -63,7 +63,7 @@
                 android:layout_marginBottom="@dimen/about_text_margin"
                 android:layout_alignParentStart="true"
                 android:layout_below="@+id/about_version"
-                style="@style/TextAppearance.AppCompat.Small"
+                android:textSize="@dimen/text_size_normal"
                 android:text="@string/about_build_date" />
 
             <!--Copyright-->
@@ -74,7 +74,7 @@
                 android:layout_alignParentStart="true"
                 android:layout_below="@+id/about_build_date"
                 android:text="@string/about_copyright"
-                style="@style/TextAppearance.AppCompat.Small" />
+                android:textSize="@dimen/text_size_normal" />
             <TextView
                 android:id="@+id/about_author"
                 android:layout_width="wrap_content"
@@ -82,7 +82,7 @@
                 android:layout_alignParentStart="true"
                 android:layout_below="@+id/about_copyright"
                 android:text="@string/author"
-                style="@style/TextAppearance.AppCompat.Small" />
+                android:textSize="@dimen/text_size_normal" />
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/content_event_info.xml
+++ b/app/src/main/res/layout/content_event_info.xml
@@ -46,7 +46,7 @@
                     android:layout_height="wrap_content"
                     style="@style/TextAppearance.AppCompat.Small"
                     android:text="@string/event_period_label"
-                    android:textSize="16sp"
+                    android:textSize="@dimen/text_size_normal"
                     android:textStyle="bold"
                     android:layout_gravity="start"/>
                 <TextView
@@ -55,7 +55,7 @@
                     android:layout_height="wrap_content"
                     style="@style/TextAppearance.AppCompat.Small"
                     android:layout_gravity="end"
-                    android:textSize="16sp"
+                    android:textSize="@dimen/text_size_normal"
                     android:gravity="end"/>
 
             </LinearLayout>
@@ -68,18 +68,16 @@
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    style="@style/TextAppearance.AppCompat.Small"
                     android:text="@string/event_next_due_label"
-                    android:textSize="16sp"
+                    android:textSize="@dimen/text_size_normal"
                     android:textStyle="bold"
                     android:layout_gravity="start"/>
                 <TextView
                     android:id="@+id/card_info_next_due_value"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    style="@style/TextAppearance.AppCompat.Small"
+                    android:textSize="@dimen/text_size_normal"
                     android:layout_gravity="end"
-                    android:textSize="16sp"
                     android:gravity="end"/>
 
             </LinearLayout>
@@ -93,19 +91,16 @@
                     android:layout_width="0dp"
                     android:layout_weight="1"
                     android:layout_height="wrap_content"
-                    style="@style/TextAppearance.AppCompat.Small"
                     android:text="@string/event_notes_label"
-                    android:textSize="16sp"
+                    android:textSize="@dimen/text_size_normal"
                     android:textStyle="bold"
-                    android:layout_gravity="start"
-                    android:paddingEnd="56dp"/>
+                    android:layout_gravity="start"/>
                 <TextView
                     android:id="@+id/card_info_notes"
                     android:layout_width="0dp"
                     android:layout_weight="2"
                     android:layout_height="wrap_content"
-                    android:textSize="16sp"
-                    style="@style/TextAppearance.AppCompat.Small"
+                    android:textSize="@dimen/text_size_normal"
                     android:layout_gravity="end"
                     android:gravity="end"/>
 

--- a/app/src/main/res/layout/dialog_sort.xml
+++ b/app/src/main/res/layout/dialog_sort.xml
@@ -10,6 +10,7 @@
         android:layout_height="wrap_content"
         android:textAlignment="viewStart"
         android:textColor="@color/colorAccent"
+        android:textSize="@dimen/text_size_normal"
         android:paddingStart="@dimen/dialog_text_padding"
         android:paddingEnd="@dimen/dialog_text_padding"
         android:paddingTop="@dimen/dialog_text_padding"/>

--- a/app/src/main/res/layout/list_item_event.xml
+++ b/app/src/main/res/layout/list_item_event.xml
@@ -53,13 +53,13 @@
                 android:id="@+id/list_event_previous_date"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="15sp"
+                android:textSize="@dimen/text_size_normal"
                 android:textColor="@color/colorDateText" />
             <TextView
                 android:id="@+id/list_event_next_date"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="15sp"
+                android:textSize="@dimen/text_size_normal"
                 android:textColor="@color/colorDateText"
                 android:gravity="end"
                 android:layout_alignParentEnd="true" />

--- a/app/src/main/res/layout/list_item_event.xml
+++ b/app/src/main/res/layout/list_item_event.xml
@@ -24,7 +24,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:textStyle="bold"
-            android:textSize="17sp"
+            android:textSize="16sp"
             android:layout_marginBottom="4dp"
             android:textColor="@color/colorText"/>
 

--- a/app/src/main/res/layout/list_item_history.xml
+++ b/app/src/main/res/layout/list_item_history.xml
@@ -16,6 +16,6 @@
         android:layout_height="wrap_content"
         android:layout_alignParentTop="true"
         android:layout_alignParentStart="true"
-        android:textSize="16sp"/>
+        android:textSize="@dimen/text_size_normal" />
 
 </RelativeLayout>

--- a/app/src/main/res/menu/menu_about.xml
+++ b/app/src/main/res/menu/menu_about.xml
@@ -1,0 +1,10 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="com.nightcap.previously.MainActivity">
+    <item
+        android:id="@+id/action_email_feedback"
+        android:orderInCategory="100"
+        android:title="@string/action_email_feedback"
+        app:showAsAction="never" />
+</menu>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -31,4 +31,6 @@
     <dimen name="about_logo_size">80dp</dimen>
     <dimen name="about_text_margin">8dp</dimen>
 
+    <dimen name="text_size_normal">15sp</dimen>
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
     <string name="pref_display_label">Display</string>
     <string name="pref_title_warning_period">Warning period in days</string>
     <string name="pref_default_warning_period">7</string>
+    <string name="action_email_feedback">Contact developer</string>
 
     <string name="pref_save_label">Saving events</string>
     <string name="pref_title_default_date">Default date</string>


### PR DESCRIPTION
Closes #28 

Added email feedback to About screen menu. This is not for us to communicate, but rather for outside testers and users who do not have direct access to our other channels.

Also tweaked UI with slightly smaller font size per Anna's request. Will consider a denser layout option later.